### PR TITLE
Improve the assert for the owner, because the owner could also appear…

### DIFF
--- a/src/lists/tests/test_views.py
+++ b/src/lists/tests/test_views.py
@@ -241,5 +241,8 @@ class ShareListTest(TestCase):
     Item.objects.create(list=list_, text="Item in Shared List") 
     list_.shared_with.add(sharee)
     response = self.client.get(f'/lists/{list_.id}/')
+    parsed = lxml.html.fromstring(response.content)
+    parsed_owner = parsed.cssselect("#id_list_owner")[0].text
     self.assertContains(response, "sharer@example.com")
+    self.assertEqual(parsed_owner, "sharer@example.com")
 


### PR DESCRIPTION
… somewhere else on the page.